### PR TITLE
Add getMediaStream function to attach MediaStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ $ npm run start
 - [`Media APIs`](#)
     - `instance.attachMedia(videoElement)`
     - `instance.getUserMedia()`
+    - `instance.getMediaStream(mediaStream)`
 - [`Streaming APIs`](#)
     - `instance.startStreaming()`
     - `instance.stopStreaming()`
@@ -245,6 +246,17 @@ ovenLivekit.getUserMedia(constraints).then(function (stream) {
         - error: Throws error while getting the stream from the user device.
 - This API is the most important API in OvenLiveKit. Make the OvenLiveKit streamable by getting the media stream from the user input device. You can get the media stream from any user input device you want using the `constraints` parameter. The device ID to be used in the `constraints` parameter can also be obtained from `OvenLiveKit.getDevices()`.
 - For natural behavior, you can have the browser automatically select the device stream without passing a `constraints` parameter. However, if you want to control the device stream strictly (e.g., specify input devices, video resolution, video frame rates), you can control it by passing the constraints parameter.
+
+#### `instance.getMediaStream(stream)`
+- parameters
+    - stream: [MediaStream](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream) - The valid MediaStream you want OvenLiveKit to utilize.
+- returns Promise
+    - resolved
+        - stream: [MediaStream](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream) - Returns the same stream provided as an input, confirming its successful attachment.
+    - rejected
+        - error: Throws an error if an invalid MediaStream is provided.
+- The `getMediaStream` function is designed to let developers directly attach an external or pre-existing MediaStream. This can be particularly useful when you're sourcing the stream not directly from user input devices, but other origins.
+
 
 ### Streaming APIs
 Congrats on getting the media stream from the user device and then ready to stream into OvenMediaEngine.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $ npm run start
 - [`Media APIs`](#)
     - `instance.attachMedia(videoElement)`
     - `instance.getUserMedia()`
-    - `instance.getMediaStream(mediaStream)`
+    - `instance.setMediaStream(mediaStream)`
 - [`Streaming APIs`](#)
     - `instance.startStreaming()`
     - `instance.stopStreaming()`
@@ -247,7 +247,7 @@ ovenLivekit.getUserMedia(constraints).then(function (stream) {
 - This API is the most important API in OvenLiveKit. Make the OvenLiveKit streamable by getting the media stream from the user input device. You can get the media stream from any user input device you want using the `constraints` parameter. The device ID to be used in the `constraints` parameter can also be obtained from `OvenLiveKit.getDevices()`.
 - For natural behavior, you can have the browser automatically select the device stream without passing a `constraints` parameter. However, if you want to control the device stream strictly (e.g., specify input devices, video resolution, video frame rates), you can control it by passing the constraints parameter.
 
-#### `instance.getMediaStream(stream)`
+#### `instance.setMediaStream(stream)`
 - parameters
     - stream: [MediaStream](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream) - The valid MediaStream you want OvenLiveKit to utilize.
 - returns Promise
@@ -255,7 +255,7 @@ ovenLivekit.getUserMedia(constraints).then(function (stream) {
         - stream: [MediaStream](https://developer.mozilla.org/en-US/docs/Web/API/MediaStream) - Returns the same stream provided as an input, confirming its successful attachment.
     - rejected
         - error: Throws an error if an invalid MediaStream is provided.
-- The `getMediaStream` function is designed to let developers directly attach an external or pre-existing MediaStream. This can be particularly useful when you're sourcing the stream not directly from user input devices, but other origins.
+- The `setMediaStream` function is designed to let developers directly attach an external or pre-existing MediaStream. This can be particularly useful when you're sourcing the stream not directly from user input devices, but other origins.
 
 
 ### Streaming APIs

--- a/src/OvenLiveKit.js
+++ b/src/OvenLiveKit.js
@@ -289,6 +289,39 @@ function addMethod(instance) {
             });
     }
 
+    function getMediaStream(stream) {
+        // Check if a valid stream is provided
+        if (!stream || !(stream instanceof MediaStream)) {
+            
+            const error = new Error("Invalid MediaStream provided");
+            console.error(logHeader, 'Invalid MediaStream', error);
+            errorHandler(error);
+    
+            return new Promise(function (resolve, reject) {
+                reject(error);
+            });
+        }
+    
+        console.info(logHeader, 'Received Media Stream', stream);
+    
+        instance.inputStream = stream;
+    
+        let elem = instance.videoElement;
+    
+        // Attach stream to video element when video element is provided.
+        if (elem) {
+            elem.srcObject = stream;
+    
+            elem.onloadedmetadata = function (e) {
+                elem.play();
+            };
+        }
+    
+        return new Promise(function (resolve) {
+            resolve(stream);
+        });
+    }
+
     // From https://webrtchacks.com/limit-webrtc-bandwidth-sdp/
     function setBitrateLimit(sdp, media, bitrate) {
 
@@ -778,6 +811,11 @@ function addMethod(instance) {
     instance.getDisplayMedia = function (constraints) {
 
         return getDisplayMedia(constraints);
+    };
+
+    instance.getMediaStream = function (stream) {
+
+        return getMediaStream(stream);
     };
 
     instance.startStreaming = function (connectionUrl, connectionConfig) {

--- a/src/OvenLiveKit.js
+++ b/src/OvenLiveKit.js
@@ -289,7 +289,7 @@ function addMethod(instance) {
             });
     }
 
-    function getMediaStream(stream) {
+    function setMediaStream(stream) {
         // Check if a valid stream is provided
         if (!stream || !(stream instanceof MediaStream)) {
             
@@ -813,9 +813,9 @@ function addMethod(instance) {
         return getDisplayMedia(constraints);
     };
 
-    instance.getMediaStream = function (stream) {
+    instance.setMediaStream = function (stream) {
 
-        return getMediaStream(stream);
+        return setMediaStream(stream);
     };
 
     instance.startStreaming = function (connectionUrl, connectionConfig) {


### PR DESCRIPTION
### Overview
I've been using OvenLiveKit-Web and noticed that there's no direct way to attach an external or pre-existing MediaStream. In the current setup, developers are limited to obtaining the media stream through getUserMedia or getDisplayMedia. To cater to diverse use-cases like mine, I've added a function called getMediaStream.

### Related Issue
This pull request is in response to the issue [#15](https://github.com/AirenSoft/OvenLiveKit-Web/issues/15) that I previously opened.

### How It Works
The getMediaStream function allows developers to pass an existing MediaStream. The internal mechanism then sets this MediaStream as the source for broadcasting, allowing for more flexible media input handling.

### Testing Done
Tested attaching an external MediaStream and broadcasting, which is working as expected.
Ensured existing getUserMedia and getDisplayMedia functionalities were unaffected.

